### PR TITLE
Add GitHub link to docs site sidebar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,7 @@
         <a href="index.html" class="active">Getting Started</a>
         <a href="what.html">How It Works</a>
       </nav>
+      <a href="https://github.com/georgecodes/fakeid" class="github-link">View on GitHub</a>
     </aside>
     <main class="main">
       <h1>Fake ID</h1>

--- a/docs/style.css
+++ b/docs/style.css
@@ -95,6 +95,22 @@ body {
   color: var(--accent);
 }
 
+.sidebar .github-link {
+  display: block;
+  margin-top: 1.5rem;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  border-radius: 6px;
+}
+
+.sidebar .github-link:hover {
+  color: var(--text);
+  background: var(--bg);
+  text-decoration: none;
+}
+
 /* Main content */
 .main {
   margin-left: 260px;

--- a/docs/what.html
+++ b/docs/what.html
@@ -19,6 +19,7 @@
         <a href="index.html">Getting Started</a>
         <a href="what.html" class="active">How It Works</a>
       </nav>
+      <a href="https://github.com/georgecodes/fakeid" class="github-link">View on GitHub</a>
     </aside>
     <main class="main">
       <h1>How It Works</h1>


### PR DESCRIPTION
The static site had the repo URL buried in a paragraph but no prominent
link back to the source code. Adds a "View on GitHub" link to the sidebar
on both pages, styled consistently with the existing nav.

https://claude.ai/code/session_01Qs74uGGXiPLYkzQ3Cuun5v