### PR TITLE
Add documentation for Java library usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,65 @@ services:
 
 The DNS entry auth.localtest.me is externally resolvable to localhost, and we have told docker to allow the fakeid container to be reached via it internally as well.
 
+## Using Fake ID as a Java library
+
+Fake ID is published to Maven Central, so you can embed it directly in a Java project — useful in integration tests
+where spinning up a Docker container would be heavy.
+
+```xml
+<dependency>
+    <groupId>com.elevenware</groupId>
+    <artifactId>fakeid</artifactId>
+    <version>0.0.3</version>
+</dependency>
+```
+
+The simplest usage starts Fake ID on a fixed port with default claims and a freshly generated signing key:
+
+```java
+Configuration configuration = Configuration.builder()
+        .port(8091)
+        .build();
+
+FakeIdApplication app = new FakeIdApplication(configuration).start();
+
+// ... point your relying party at http://localhost:8091 ...
+
+app.stop();
+```
+
+For tests, bind to an ephemeral port and read it back from the running application:
+
+```java
+FakeIdApplication app = new FakeIdApplication(Configuration.builder().build()).start();
+int port = app.port();
+String issuer = "http://localhost:" + port;
+```
+
+You can supply your own signing key (so JWKS is stable across restarts) and override the claims that will
+be returned in id tokens:
+
+```java
+RSAKey jwk = new RSAKeyGenerator(2048)
+        .keyUse(KeyUse.SIGNATURE)
+        .keyID("signingKey")
+        .algorithm(Algorithm.parse("RS256"))
+        .generate();
+
+Configuration configuration = Configuration.builder()
+        .port(8091)
+        .jwks(new JWKSet(jwk))
+        .claims(Map.of(
+                "sub", "jeff@example.com",
+                "additionalClaims", Map.of("claim", "claimValue")))
+        .build();
+
+FakeIdApplication app = new FakeIdApplication(configuration).start();
+```
+
+Everything the Docker image exposes via environment variables is available on the `Configuration.Builder`, so library
+and container usage share the same underlying configuration model.
+
 ## Configuration
 
 There are a few ways to configure Fake ID. The simplest way is to simply start the container, and allow it to provide sensible defaults.

--- a/README.md
+++ b/README.md
@@ -74,16 +74,24 @@ FakeIdApplication app = new FakeIdApplication(configuration).start();
 app.stop();
 ```
 
-For tests, bind to an ephemeral port and read it back from the running application:
+For tests, bind to an ephemeral port with `randomPort()` (or `.port(0)`) and read the actual port back from the
+running application. Stop the application in a `finally` block so a failing test doesn't leak a running server:
 
 ```java
-FakeIdApplication app = new FakeIdApplication(Configuration.builder().build()).start();
-int port = app.port();
-String issuer = "http://localhost:" + port;
+FakeIdApplication app = new FakeIdApplication(
+        Configuration.builder().randomPort().build()).start();
+try {
+    int port = app.port();
+    String issuer = "http://localhost:" + port;
+    // ... exercise your relying party against `issuer` ...
+} finally {
+    app.stop();
+}
 ```
 
-You can supply your own signing key (so JWKS is stable across restarts) and override the claims that will
-be returned in id tokens:
+You can supply your own signing key and override the claims returned in id tokens. Providing a key you persist
+and reuse across restarts keeps the JWKS stable — generating a fresh key on every startup (as shown below) will
+give a different JWKS each run, which matters if relying parties cache it:
 
 ```java
 RSAKey jwk = new RSAKeyGenerator(2048)
@@ -103,8 +111,11 @@ Configuration configuration = Configuration.builder()
 FakeIdApplication app = new FakeIdApplication(configuration).start();
 ```
 
-Everything the Docker image exposes via environment variables is available on the `Configuration.Builder`, so library
-and container usage share the same underlying configuration model.
+The Java library and Docker image share the same underlying configuration model, but the builder does not map 1:1
+to every environment-variable format. For example, `FAKEID_CONFIG_LOCATION` is handled via
+`Configuration.loadFromFile(...)`, and `FAKEID_SIGNING_KEY` (a base64-encoded PEM) is parsed into a `JWKSet` rather
+than accepted directly by the builder. For environment-variable or file-based parity, use
+`Configuration.defaultConfiguration()` or `Configuration.loadFromFile(...)`.
 
 ## Configuration
 

--- a/docs/content/library.md
+++ b/docs/content/library.md
@@ -37,8 +37,16 @@ implementation 'com.elevenware:fakeid:0.0.3'
 ## Starting Fake ID in code
 
 The entry point is `FakeIdApplication`, which takes a `Configuration` and exposes `start()`, `stop()`, and
-`port()`. The builder accepts the same options as the environment variables documented on the Getting Started
-page.
+`port()`. There are three ways to build a `Configuration`:
+
+- `Configuration.defaultConfiguration()` reads the environment variables documented on the Getting Started page.
+- `Configuration.loadFromFile(path)` loads a JSON configuration file (the same file `FAKEID_CONFIG_LOCATION`
+  points at in the Docker image).
+- `Configuration.builder()` is for explicit in-code setup.
+
+The three approaches share the same underlying configuration model, but the builder does not map 1:1 to every
+environment-variable format — for example, `FAKEID_SIGNING_KEY` is a base64-encoded PEM that gets parsed into a
+`JWKSet`, whereas the builder's `jwks(...)` method takes a `JWKSet` directly.
 
 ### Minimal
 
@@ -56,17 +64,30 @@ app.stop();
 
 ### Ephemeral port for tests
 
-If you omit `port(...)`, Fake ID binds to a free port. Read it back from the started application:
+To bind to a free port in tests, use `randomPort()` (or `.port(0)`). Read the actual port back from the started
+application, and stop the application in a `finally` block so a failing assertion doesn't leak a running server:
 
 ```java
-FakeIdApplication app = new FakeIdApplication(Configuration.builder().build()).start();
-int port = app.port();
-String issuer = "http://localhost:" + port;
+FakeIdApplication app = new FakeIdApplication(
+        Configuration.builder()
+                .randomPort()
+                .build())
+        .start();
+
+try {
+    int port = app.port();
+    String issuer = "http://localhost:" + port;
+    // ... exercise your relying party against `issuer` ...
+} finally {
+    app.stop();
+}
 ```
 
 ### Fully configured
 
-Supply your own signing key (so the JWKS is stable across restarts) and override the claims returned in id tokens:
+Supply your own signing key and override the claims returned in id tokens. Providing a key you persist and reuse
+across startups keeps the JWKS stable — generating a fresh key on every start (as shown below) produces a
+different JWKS each run, which can cause signature-verification errors in relying parties that cache the JWKS:
 
 ```java
 RSAKey jwk = new RSAKeyGenerator(2048)
@@ -98,7 +119,9 @@ class MyOidcIntegrationTest {
 
     @BeforeAll
     static void startFakeId() {
-        fakeId = new FakeIdApplication(Configuration.builder().build()).start();
+        fakeId = new FakeIdApplication(
+                Configuration.builder().randomPort().build())
+                .start();
         issuer = "http://localhost:" + fakeId.port();
     }
 

--- a/docs/content/library.md
+++ b/docs/content/library.md
@@ -1,0 +1,127 @@
+---
+title: "Java Library"
+subtitle: "Embedding Fake ID directly in a Java project"
+menu:
+  main:
+    name: "Java Library"
+    weight: 15
+---
+
+## Why embed Fake ID?
+
+Running Fake ID in Docker is the common case, but sometimes you just want an OIDC provider running inside a JVM
+test &mdash; no container runtime, no port collisions, no image pulls. Fake ID is published to Maven Central and
+exposes the same configuration model as the Docker image, so you can start it in-process and shut it down when
+your test is done.
+
+## Add the dependency
+
+Fake ID is published under `com.elevenware:fakeid` on Maven Central.
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>com.elevenware</groupId>
+    <artifactId>fakeid</artifactId>
+    <version>0.0.3</version>
+</dependency>
+```
+
+### Gradle
+
+```groovy
+implementation 'com.elevenware:fakeid:0.0.3'
+```
+
+## Starting Fake ID in code
+
+The entry point is `FakeIdApplication`, which takes a `Configuration` and exposes `start()`, `stop()`, and
+`port()`. The builder accepts the same options as the environment variables documented on the Getting Started
+page.
+
+### Minimal
+
+```java
+Configuration configuration = Configuration.builder()
+        .port(8091)
+        .build();
+
+FakeIdApplication app = new FakeIdApplication(configuration).start();
+
+// ... your relying party points at http://localhost:8091 ...
+
+app.stop();
+```
+
+### Ephemeral port for tests
+
+If you omit `port(...)`, Fake ID binds to a free port. Read it back from the started application:
+
+```java
+FakeIdApplication app = new FakeIdApplication(Configuration.builder().build()).start();
+int port = app.port();
+String issuer = "http://localhost:" + port;
+```
+
+### Fully configured
+
+Supply your own signing key (so the JWKS is stable across restarts) and override the claims returned in id tokens:
+
+```java
+RSAKey jwk = new RSAKeyGenerator(2048)
+        .keyUse(KeyUse.SIGNATURE)
+        .keyID("signingKey")
+        .algorithm(Algorithm.parse("RS256"))
+        .generate();
+
+Configuration configuration = Configuration.builder()
+        .port(8091)
+        .jwks(new JWKSet(jwk))
+        .claims(Map.of(
+                "sub", "jeff@example.com",
+                "additionalClaims", Map.of("claim", "claimValue")))
+        .build();
+
+FakeIdApplication app = new FakeIdApplication(configuration).start();
+```
+
+## Using it in a JUnit 5 test
+
+A typical pattern is to start Fake ID once per test class, then point a relying party at it:
+
+```java
+class MyOidcIntegrationTest {
+
+    private static FakeIdApplication fakeId;
+    private static String issuer;
+
+    @BeforeAll
+    static void startFakeId() {
+        fakeId = new FakeIdApplication(Configuration.builder().build()).start();
+        issuer = "http://localhost:" + fakeId.port();
+    }
+
+    @AfterAll
+    static void stopFakeId() {
+        fakeId.stop();
+    }
+
+    @Test
+    void discoveryDocumentIsServed() throws Exception {
+        HttpResponse<String> response = HttpClient.newHttpClient()
+                .send(HttpRequest.newBuilder()
+                        .uri(URI.create(issuer + "/.well-known/openid-configuration"))
+                        .GET()
+                        .build(),
+                        HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+    }
+}
+```
+
+## Caveats
+
+Fake ID currently ships Javalin as a runtime dependency, so the library form pulls in an embedded HTTP server
+even when used in tests. That's intentional &mdash; the server is what makes it useful as an OIDC provider &mdash; but
+it's worth knowing if you're auditing your test classpath.


### PR DESCRIPTION
## Summary
Added comprehensive documentation for using Fake ID as an embedded Java library in projects, particularly for integration testing scenarios.

## Changes
- **New documentation page** (`docs/content/library.md`): Complete guide covering:
  - Rationale for embedding Fake ID in Java projects
  - Maven and Gradle dependency declarations
  - Multiple usage examples (minimal, ephemeral port, fully configured)
  - JUnit 5 integration pattern with lifecycle management
  - Known caveats about Javalin runtime dependency

- **Updated README.md**: Added a new "Using Fake ID as a Java library" section with:
  - Quick reference to Maven Central availability
  - Three practical code examples showing different configuration levels
  - Note about configuration model parity between Docker and library usage

## Implementation Details
The documentation demonstrates the `FakeIdApplication` and `Configuration` APIs, showing how users can:
- Start/stop the OIDC provider programmatically
- Bind to fixed or ephemeral ports
- Supply custom signing keys and claims
- Integrate with test frameworks via lifecycle hooks

All examples use the same configuration model as the Docker image, emphasizing consistency across deployment methods.

https://claude.ai/code/session_01BZSHFXAiJJ6bxNkyXniZN1