### PR TITLE
Add DTO records under core.dto (no wiring yet)

### DIFF
--- a/src/main/java/com/elevenware/fakeid/core/dto/AuthorizeRequest.java
+++ b/src/main/java/com/elevenware/fakeid/core/dto/AuthorizeRequest.java
@@ -1,0 +1,32 @@
+package com.elevenware.fakeid.core.dto;
+
+/*-
+ * #%L
+ * Fake ID
+ * %%
+ * Copyright (C) 2025 George McIntosh
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Set;
+
+public record AuthorizeRequest(
+        String clientId,
+        String redirectUri,
+        String responseType,
+        Set<String> scopes,
+        String state,
+        String nonce) {
+}

--- a/src/main/java/com/elevenware/fakeid/core/dto/AuthorizeResponse.java
+++ b/src/main/java/com/elevenware/fakeid/core/dto/AuthorizeResponse.java
@@ -1,0 +1,29 @@
+package com.elevenware.fakeid.core.dto;
+
+/*-
+ * #%L
+ * Fake ID
+ * %%
+ * Copyright (C) 2025 George McIntosh
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public record AuthorizeResponse(
+        String redirectUri,
+        String code,
+        String accessToken,
+        String idToken,
+        String state) {
+}

--- a/src/main/java/com/elevenware/fakeid/core/dto/AuthorizeResponse.java
+++ b/src/main/java/com/elevenware/fakeid/core/dto/AuthorizeResponse.java
@@ -26,4 +26,13 @@ public record AuthorizeResponse(
         String accessToken,
         String idToken,
         String state) {
+
+    @Override
+    public String toString() {
+        return "AuthorizeResponse[redirectUri=" + redirectUri
+                + ", code=[REDACTED]"
+                + ", accessToken=[REDACTED]"
+                + ", idToken=[REDACTED]"
+                + ", state=" + state + "]";
+    }
 }

--- a/src/main/java/com/elevenware/fakeid/core/dto/IntrospectRequest.java
+++ b/src/main/java/com/elevenware/fakeid/core/dto/IntrospectRequest.java
@@ -1,0 +1,24 @@
+package com.elevenware.fakeid.core.dto;
+
+/*-
+ * #%L
+ * Fake ID
+ * %%
+ * Copyright (C) 2025 George McIntosh
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public record IntrospectRequest(String token) {
+}

--- a/src/main/java/com/elevenware/fakeid/core/dto/IntrospectRequest.java
+++ b/src/main/java/com/elevenware/fakeid/core/dto/IntrospectRequest.java
@@ -21,4 +21,8 @@ package com.elevenware.fakeid.core.dto;
  */
 
 public record IntrospectRequest(String token) {
+    @Override
+    public String toString() {
+        return "IntrospectRequest[token=[REDACTED]]";
+    }
 }

--- a/src/main/java/com/elevenware/fakeid/core/dto/IntrospectResponse.java
+++ b/src/main/java/com/elevenware/fakeid/core/dto/IntrospectResponse.java
@@ -1,0 +1,30 @@
+package com.elevenware.fakeid.core.dto;
+
+/*-
+ * #%L
+ * Fake ID
+ * %%
+ * Copyright (C) 2025 George McIntosh
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public record IntrospectResponse(
+        boolean active,
+        String clientId,
+        String sub,
+        String scope,
+        Long exp,
+        Long iat) {
+}

--- a/src/main/java/com/elevenware/fakeid/core/dto/TokenRequest.java
+++ b/src/main/java/com/elevenware/fakeid/core/dto/TokenRequest.java
@@ -1,0 +1,29 @@
+package com.elevenware.fakeid.core.dto;
+
+/*-
+ * #%L
+ * Fake ID
+ * %%
+ * Copyright (C) 2025 George McIntosh
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public record TokenRequest(
+        String grantType,
+        String code,
+        String scope,
+        String clientId,
+        String clientSecret) {
+}

--- a/src/main/java/com/elevenware/fakeid/core/dto/TokenResponse.java
+++ b/src/main/java/com/elevenware/fakeid/core/dto/TokenResponse.java
@@ -29,4 +29,18 @@ public record TokenResponse(
         String clientId,
         String grantType,
         String idToken) {
+
+    @Override
+    public String toString() {
+        return "TokenResponse[" +
+                "accessToken=" + (accessToken == null ? null : "[REDACTED]") +
+                ", tokenType=" + tokenType +
+                ", expiresIn=" + expiresIn +
+                ", scope=" + scope +
+                ", issuedAt=" + issuedAt +
+                ", clientId=" + clientId +
+                ", grantType=" + grantType +
+                ", idToken=" + (idToken == null ? null : "[REDACTED]") +
+                "]";
+    }
 }

--- a/src/main/java/com/elevenware/fakeid/core/dto/TokenResponse.java
+++ b/src/main/java/com/elevenware/fakeid/core/dto/TokenResponse.java
@@ -1,0 +1,32 @@
+package com.elevenware.fakeid.core.dto;
+
+/*-
+ * #%L
+ * Fake ID
+ * %%
+ * Copyright (C) 2025 George McIntosh
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public record TokenResponse(
+        String accessToken,
+        String tokenType,
+        long expiresIn,
+        String scope,
+        long issuedAt,
+        String clientId,
+        String grantType,
+        String idToken) {
+}


### PR DESCRIPTION
Second step of the Javalin decoupling. Introduces framework-neutral request/response records that the forthcoming FakeIdCore will use as its public in-JVM API surface. Nothing is wired up yet — the existing Javalin endpoints still pass Maps directly to ctx.json(), unchanged.

Records added:
- AuthorizeRequest, AuthorizeResponse
- TokenRequest, TokenResponse
- IntrospectRequest, IntrospectResponse

Intentionally skipped:
- UserInfoResponse / DiscoveryDocument — these stay as Map<String,Object> passthroughs to avoid re-modelling the oidc4j output.
- Method bodies (toRedirectLocation, JSON-naming annotations) — added in the step that wires each DTO into a real call site.

All 25 tests still pass.