### PR TITLE
Introduce OidcException hierarchy and convert unsupported_grant_type

### DIFF
--- a/src/main/java/com/elevenware/fakeid/FakeIdApplication.java
+++ b/src/main/java/com/elevenware/fakeid/FakeIdApplication.java
@@ -20,6 +20,7 @@ package com.elevenware.fakeid;
  * #L%
  */
 
+import com.elevenware.fakeid.core.error.OidcException;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import io.javalin.Javalin;
@@ -27,6 +28,7 @@ import io.javalin.json.JavalinJackson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.Optional;
 
 public class FakeIdApplication {
@@ -48,20 +50,24 @@ public class FakeIdApplication {
         var provider = new FakeIdProvider(configuration);
 
         server = Javalin.create(c -> {
-                    c.jsonMapper(jsonMapper);
-                    c.bundledPlugins.enableCors(cors -> {
-                        cors.addRule(it -> {
-                            it.anyHost();
-                        });
-                    });
-                    c.routes.get("/.well-known/openid-configuration", provider::getDiscoveryDocument);
-                    c.routes.get("/jwks", provider::jwksEndpoint);
-                    c.routes.get("/authorize", provider::authorizationEndpoint);
-                    c.routes.post("/token", provider::tokenEndpoint);
-                    c.routes.post("/token/introspect", provider::introspectionEndpoint);
-                    c.routes.get("/userinfo", provider::userInfoEndpoint);
-                })
-                .start(configuration.getPort());
+            c.jsonMapper(jsonMapper);
+            c.bundledPlugins.enableCors(cors -> {
+                cors.addRule(it -> {
+                    it.anyHost();
+                });
+            });
+            c.routes.exception(OidcException.class, (e, ctx) -> ctx
+                    .status(e.httpStatus())
+                    .json(Map.of(
+                            "error", e.error(),
+                            "error_description", e.errorDescription())));
+            c.routes.get("/.well-known/openid-configuration", provider::getDiscoveryDocument);
+            c.routes.get("/jwks", provider::jwksEndpoint);
+            c.routes.get("/authorize", provider::authorizationEndpoint);
+            c.routes.post("/token", provider::tokenEndpoint);
+            c.routes.post("/token/introspect", provider::introspectionEndpoint);
+            c.routes.get("/userinfo", provider::userInfoEndpoint);
+        }).start(configuration.getPort());
         LOG.info("Fake ID started");
         return this;
     }

--- a/src/main/java/com/elevenware/fakeid/FakeIdProvider.java
+++ b/src/main/java/com/elevenware/fakeid/FakeIdProvider.java
@@ -20,6 +20,7 @@ package com.elevenware.fakeid;
  * #L%
  */
 
+import com.elevenware.fakeid.core.error.UnsupportedGrantTypeException;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -148,7 +149,7 @@ public class FakeIdProvider {
                 context.json(response);
                 break;
             default:
-                context.status(400).json(Map.of("error", "unsupported_grant_type", "error_description", "unsupported grant type: " + grantTypeName));
+                throw new UnsupportedGrantTypeException(grantTypeName);
         }
 
     }

--- a/src/main/java/com/elevenware/fakeid/core/error/OidcException.java
+++ b/src/main/java/com/elevenware/fakeid/core/error/OidcException.java
@@ -1,0 +1,47 @@
+package com.elevenware.fakeid.core.error;
+
+/*-
+ * #%L
+ * Fake ID
+ * %%
+ * Copyright (C) 2025 George McIntosh
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public abstract class OidcException extends RuntimeException {
+
+    private final String error;
+    private final String errorDescription;
+    private final int httpStatus;
+
+    protected OidcException(String error, String errorDescription, int httpStatus) {
+        super(error + ": " + errorDescription);
+        this.error = error;
+        this.errorDescription = errorDescription;
+        this.httpStatus = httpStatus;
+    }
+
+    public String error() {
+        return error;
+    }
+
+    public String errorDescription() {
+        return errorDescription;
+    }
+
+    public int httpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/elevenware/fakeid/core/error/UnsupportedGrantTypeException.java
+++ b/src/main/java/com/elevenware/fakeid/core/error/UnsupportedGrantTypeException.java
@@ -1,0 +1,28 @@
+package com.elevenware.fakeid.core.error;
+
+/*-
+ * #%L
+ * Fake ID
+ * %%
+ * Copyright (C) 2025 George McIntosh
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public class UnsupportedGrantTypeException extends OidcException {
+
+    public UnsupportedGrantTypeException(String grantType) {
+        super("unsupported_grant_type", "unsupported grant type: " + grantType, 400);
+    }
+}

--- a/src/test/java/com/elevenware/fakeid/ClientCredentialsGrantTests.java
+++ b/src/test/java/com/elevenware/fakeid/ClientCredentialsGrantTests.java
@@ -138,5 +138,28 @@ public class ClientCredentialsGrantTests {
         assertEquals(401, response.statusCode());
     }
 
+    @Test
+    void unknownGrantTypeIsRejected() throws IOException, InterruptedException {
+
+        HttpClient client = HttpClient.newHttpClient();
+
+        Map<String, String> tokenRequest = Map.of(
+                "grant_type", "made_up_grant",
+                "client_id", "client1",
+                "client_secret", "secret1"
+        );
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://localhost:%d/token", port)))
+                .POST(HttpRequest.BodyPublishers.ofString(getFormDataAsString(tokenRequest)))
+                .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, response.statusCode());
+        Map<String, Object> body = TestUtils.mapper().readValue(response.body(), Map.class);
+        assertEquals("unsupported_grant_type", body.get("error"));
+        assertEquals("unsupported grant type: made_up_grant", body.get("error_description"));
+    }
+
 
 }


### PR DESCRIPTION
Third step of the Javalin decoupling. Adds a framework-neutral exception family so the forthcoming FakeIdCore can signal OIDC errors without reaching for Javalin's Context. The Javalin adapter registers a single mapper in FakeIdApplication.start() that translates any OidcException into the same JSON shape the inline handlers produced before.

Converted one call site as proof of concept: the 'unsupported grant type' default branch in FakeIdProvider.tokenEndpoint now throws UnsupportedGrantTypeException, which the mapper renders as a 400 with the original body. Other error paths (invalid_request, invalid_client, unknown auth code) stay inline for now — they'll migrate as their endpoints move into FakeIdCore.

Added a regression test capturing the current wire format for that branch before the refactor, so any future drift is caught at the HTTP boundary. 26/26 tests pass.