### PR TITLE
Refactor token endpoint logic into FakeIdCore class

### DIFF
--- a/src/main/java/com/elevenware/fakeid/FakeIdProvider.java
+++ b/src/main/java/com/elevenware/fakeid/FakeIdProvider.java
@@ -20,8 +20,10 @@ package com.elevenware.fakeid;
  * #L%
  */
 
+import com.elevenware.fakeid.core.FakeIdCore;
 import com.elevenware.fakeid.core.TokenMinter;
-import com.elevenware.fakeid.core.error.UnsupportedGrantTypeException;
+import com.elevenware.fakeid.core.dto.TokenRequest;
+import com.elevenware.fakeid.core.dto.TokenResponse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.oidc4j.v2.lib.Provider;
 import com.oidc4j.v2.lib.ProviderConfiguration;
@@ -42,7 +44,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class FakeIdProvider {
 
@@ -51,12 +52,13 @@ public class FakeIdProvider {
     private final Configuration configuration;
     private final Provider provider;
     private final TokenMinter tokenMinter;
-    private final Map<String, String> noncesByCode = new ConcurrentHashMap<>();
+    private final FakeIdCore core;
 
     public FakeIdProvider(Configuration configuration) {
         this.configuration = configuration;
         this.provider = buildV2Provider(configuration);
         this.tokenMinter = new TokenMinter(provider.getKeySource().getSigningKey(), configuration.getIssuer());
+        this.core = new FakeIdCore(configuration, provider, tokenMinter);
     }
 
     private static Provider buildV2Provider(Configuration configuration) {
@@ -124,29 +126,27 @@ public class FakeIdProvider {
         LOG.info("Token endpoint request parameters: {}", params);
         LOG.info("Grant type: {}", grantTypeName);
 
-        if(grantTypeName == null) {
+        if (grantTypeName == null) {
             context.status(400).json(Map.of("error", "invalid_request", "error_description", "missing required parameter: grant_type"));
             return;
         }
 
         ClientCredentials credentials = extractClientCredentials(context);
 
-        switch (grantTypeName) {
-            case "authorization_code":
-                context.json(authCodeGrant(authCode, scope));
-                break;
-            case "client_credentials":
-                if(credentials == null) {
-                    context.status(401).json(Map.of("error", "invalid_client", "error_description", "client credentials are required"));
-                    return;
-                }
-                Map<String, Object> response = clientCredentialsGrant(credentials.clientId, scope);
-                context.json(response);
-                break;
-            default:
-                throw new UnsupportedGrantTypeException(grantTypeName);
+        if ("client_credentials".equals(grantTypeName) && credentials == null) {
+            context.status(401).json(Map.of("error", "invalid_client", "error_description", "client credentials are required"));
+            return;
         }
 
+        TokenRequest tokenRequest = new TokenRequest(
+                grantTypeName,
+                authCode,
+                scope,
+                credentials == null ? null : credentials.clientId,
+                credentials == null ? null : credentials.clientSecret);
+
+        TokenResponse response = core.token(tokenRequest);
+        context.json(response);
     }
 
     private ClientCredentials extractClientCredentials(Context context) {
@@ -253,7 +253,7 @@ public class FakeIdProvider {
         pending.grant();
         provider.getPendingGrantStore().save(pending);
         if (nonce != null) {
-            noncesByCode.put(code, nonce);
+            core.recordAuthCodeNonce(code, nonce);
         }
     }
 
@@ -286,66 +286,6 @@ public class FakeIdProvider {
         } else {
             context.json(Map.of("active", false));
         }
-    }
-
-    private Map<String, Object> authCodeGrant(String authCode, String scope) {
-        com.oidc4j.v2.lib.store.PendingGrant pending = provider.getPendingGrantStore()
-                .consume(authCode)
-                .orElseThrow(() -> new IllegalStateException("Unknown authorization code: " + authCode));
-        String clientId = pending.getClientId();
-        String idToken = null;
-        Set<String> scopes = pending.getConsentedScopes();
-        if(scopes == null) {
-            scopes = Collections.emptySet();
-        }
-        if(scope == null) {
-            scope = String.join(" ", scopes);
-        }
-        if(scope.contains("openid")) {
-            idToken = idToken(noncesByCode.remove(authCode), clientId);
-        } else {
-            noncesByCode.remove(authCode);
-        }
-        String accessToken = RandomStringUtils.randomAlphanumeric(32);
-        saveIssuedGrant(clientId, "authorization_code", scopes, accessToken);
-
-        LOG.info("Token issued using auth code grant for client {}", clientId);
-        Map<String,Object> res = new HashMap<>();
-        res.put("access_token", accessToken);
-        res.put("token_type", "Bearer");
-        res.put("expires_in", 3600);
-        res.put("scope", scope);
-        res.put("issued_at", System.currentTimeMillis() / 1000L);
-        res.put("client_id", clientId);
-        res.put("grant_type", "authorization_code");
-        if(idToken != null) {
-            res.put("id_token", idToken);
-        }
-        return res;
-    }
-
-    private Map<String, Object> clientCredentialsGrant(String clientId, String scope) {
-        String accessToken = RandomStringUtils.randomAlphanumeric(32);
-        Set<String> scopes = new HashSet<>();
-        if(scope != null){
-            for(String s: scope.split(" ")) {
-                scopes.add(s);
-            }
-        } else {
-            scope = "";
-        }
-        saveIssuedGrant(clientId, "client_credentials", scopes, accessToken);
-
-        LOG.info("Token issued using client credentials grant for client {}", clientId);
-        Map<String,Object> res = new HashMap<>();
-        res.put("access_token", accessToken);
-        res.put("token_type", "Bearer");
-        res.put("expires_in", 3600);
-        res.put("scope", scope);
-        res.put("issued_at", System.currentTimeMillis() / 1000L);
-        res.put("client_id", clientId);
-        res.put("grant_type", "client_credentials");
-        return res;
     }
 
     private void saveIssuedGrant(String clientId, String grantType, Set<String> scopes, String accessToken) {

--- a/src/main/java/com/elevenware/fakeid/core/FakeIdCore.java
+++ b/src/main/java/com/elevenware/fakeid/core/FakeIdCore.java
@@ -1,0 +1,147 @@
+package com.elevenware.fakeid.core;
+
+/*-
+ * #%L
+ * Fake ID
+ * %%
+ * Copyright (C) 2025 George McIntosh
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.elevenware.fakeid.Configuration;
+import com.elevenware.fakeid.core.dto.TokenRequest;
+import com.elevenware.fakeid.core.dto.TokenResponse;
+import com.elevenware.fakeid.core.error.UnsupportedGrantTypeException;
+import com.oidc4j.v2.lib.Provider;
+import com.oidc4j.v2.lib.store.IssuedGrant;
+import com.oidc4j.v2.lib.store.PendingGrant;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class FakeIdCore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FakeIdCore.class);
+
+    private final Configuration configuration;
+    private final Provider provider;
+    private final TokenMinter tokenMinter;
+    private final Map<String, String> noncesByCode = new ConcurrentHashMap<>();
+
+    public FakeIdCore(Configuration configuration, Provider provider, TokenMinter tokenMinter) {
+        this.configuration = configuration;
+        this.provider = provider;
+        this.tokenMinter = tokenMinter;
+    }
+
+    public TokenResponse token(TokenRequest request) {
+        String grantType = request.grantType();
+        switch (grantType) {
+            case "authorization_code":
+                return authCodeGrant(request.code(), request.scope());
+            case "client_credentials":
+                return clientCredentialsGrant(request.clientId(), request.scope());
+            default:
+                throw new UnsupportedGrantTypeException(grantType);
+        }
+    }
+
+    public void recordAuthCodeNonce(String code, String nonce) {
+        noncesByCode.put(code, nonce);
+    }
+
+    private TokenResponse authCodeGrant(String authCode, String scope) {
+        PendingGrant pending = provider.getPendingGrantStore()
+                .consume(authCode)
+                .orElseThrow(() -> new IllegalStateException("Unknown authorization code: " + authCode));
+        String clientId = pending.getClientId();
+        String idToken = null;
+        Set<String> scopes = pending.getConsentedScopes();
+        if (scopes == null) {
+            scopes = Collections.emptySet();
+        }
+        if (scope == null) {
+            scope = String.join(" ", scopes);
+        }
+        if (scope.contains("openid")) {
+            idToken = tokenMinter.mintIdToken(
+                    configuration.getClaims().get("sub").toString(),
+                    clientId,
+                    noncesByCode.remove(authCode),
+                    configuration.getClaims());
+        } else {
+            noncesByCode.remove(authCode);
+        }
+        String accessToken = RandomStringUtils.randomAlphanumeric(32);
+        saveIssuedGrant(clientId, "authorization_code", scopes, accessToken);
+
+        LOG.info("Token issued using auth code grant for client {}", clientId);
+        return new TokenResponse(
+                accessToken,
+                "Bearer",
+                3600,
+                scope,
+                System.currentTimeMillis() / 1000L,
+                clientId,
+                "authorization_code",
+                idToken);
+    }
+
+    private TokenResponse clientCredentialsGrant(String clientId, String scope) {
+        String accessToken = RandomStringUtils.randomAlphanumeric(32);
+        Set<String> scopes = new HashSet<>();
+        if (scope != null) {
+            for (String s : scope.split(" ")) {
+                scopes.add(s);
+            }
+        } else {
+            scope = "";
+        }
+        saveIssuedGrant(clientId, "client_credentials", scopes, accessToken);
+
+        LOG.info("Token issued using client credentials grant for client {}", clientId);
+        return new TokenResponse(
+                accessToken,
+                "Bearer",
+                3600,
+                scope,
+                System.currentTimeMillis() / 1000L,
+                clientId,
+                "client_credentials",
+                null);
+    }
+
+    private void saveIssuedGrant(String clientId, String grantType, Set<String> scopes, String accessToken) {
+        Instant now = Instant.now();
+        provider.getIssuedGrantStore().save(new IssuedGrant(
+                UUID.randomUUID().toString(),
+                clientId,
+                grantType,
+                scopes,
+                accessToken,
+                null,
+                now,
+                now.plus(1L, ChronoUnit.HOURS)));
+    }
+}

--- a/src/test/java/com/elevenware/fakeid/IdTokenSigningTests.java
+++ b/src/test/java/com/elevenware/fakeid/IdTokenSigningTests.java
@@ -20,6 +20,7 @@ package com.elevenware.fakeid;
  * #L%
  */
 
+import com.elevenware.fakeid.core.dto.TokenResponse;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
@@ -36,7 +37,6 @@ import org.mockito.Mockito;
 
 import java.text.ParseException;
 import java.util.Date;
-import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,10 +61,9 @@ public class IdTokenSigningTests {
         when(context.formParam("code")).thenReturn(code);
 
         fakeIdProvider.tokenEndpoint(context);
-        ArgumentCaptor<Map> contextCaptor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<TokenResponse> contextCaptor = ArgumentCaptor.forClass(TokenResponse.class);
         verify(context).json(contextCaptor.capture());
-        Map<String, String> response = (Map<String, String>) contextCaptor.getValue();
-        String idToken = response.get("id_token");
+        String idToken = contextCaptor.getValue().idToken();
 
         SignedJWT jwt = SignedJWT.parse(idToken);
         JWSAlgorithm algorithm = jwt.getHeader().getAlgorithm();
@@ -96,10 +95,9 @@ public class IdTokenSigningTests {
         when(context.formParam("code")).thenReturn(code);
 
         fakeIdProvider.tokenEndpoint(context);
-        ArgumentCaptor<Map> contextCaptor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<TokenResponse> contextCaptor = ArgumentCaptor.forClass(TokenResponse.class);
         verify(context).json(contextCaptor.capture());
-        Map<String, String> response = (Map<String, String>) contextCaptor.getValue();
-        String idToken = response.get("id_token");
+        String idToken = contextCaptor.getValue().idToken();
 
         SignedJWT jwt = SignedJWT.parse(idToken);
         JWSAlgorithm algorithm = jwt.getHeader().getAlgorithm();
@@ -129,10 +127,9 @@ public class IdTokenSigningTests {
         when(context.formParam("code")).thenReturn(code);
 
         fakeIdProvider.tokenEndpoint(context);
-        ArgumentCaptor<Map> contextCaptor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<TokenResponse> contextCaptor = ArgumentCaptor.forClass(TokenResponse.class);
         verify(context).json(contextCaptor.capture());
-        Map<String, String> response = (Map<String, String>) contextCaptor.getValue();
-        String idToken = response.get("id_token");
+        String idToken = contextCaptor.getValue().idToken();
 
         SignedJWT jwt = SignedJWT.parse(idToken);
         JWSAlgorithm algorithm = jwt.getHeader().getAlgorithm();


### PR DESCRIPTION
## Summary
Extracted token grant handling logic from `FakeIdProvider` into a new `FakeIdCore` class to improve separation of concerns and testability. The core token processing logic is now decoupled from the HTTP endpoint handling.

## Key Changes
- **New `FakeIdCore` class**: Created a dedicated class to handle token grant processing, including:
  - Authorization code grant flow
  - Client credentials grant flow
  - Nonce recording and retrieval for OpenID Connect
  - Issued grant persistence
  
- **New DTOs**: Introduced `TokenRequest` and `TokenResponse` classes to encapsulate token endpoint data, replacing ad-hoc `Map` usage

- **Refactored `FakeIdProvider`**:
  - Removed `authCodeGrant()` and `clientCredentialsGrant()` methods (moved to `FakeIdCore`)
  - Removed `noncesByCode` map (moved to `FakeIdCore`)
  - Simplified `tokenEndpoint()` to delegate to `FakeIdCore.token()`
  - Updated `savePendingAuthCode()` to use `core.recordAuthCodeNonce()`

- **Updated tests**: Modified `IdTokenSigningTests` to work with `TokenResponse` objects instead of generic `Map` objects, improving type safety

## Implementation Details
- `FakeIdCore` maintains its own `noncesByCode` map for managing OpenID Connect nonces
- Token response generation is now centralized in `TokenResponse` DTO
- Grant type validation and error handling remain in `FakeIdCore`
- HTTP-specific concerns (status codes, error responses) remain in `FakeIdProvider`

https://claude.ai/code/session_01BZSHFXAiJJ6bxNkyXniZN1